### PR TITLE
window-icon.rs - Change Res<WinitWindows> to NonSend<WinitWindows> to prevent window deadlock

### DIFF
--- a/src/code/examples/window-icon.rs
+++ b/src/code/examples/window-icon.rs
@@ -6,7 +6,7 @@ use bevy::winit::WinitWindows;
 use winit::window::Icon;
 
 fn set_window_icon(
-    windows: Res<WinitWindows>,
+    windows: NonSend<WinitWindows>,
 ) {
     let primary = windows.get_window(WindowId::primary()).unwrap();
 


### PR DESCRIPTION
Sometimes updating the Window Icon from outside of the main thread can cause the Window to be unresponsive on start up, as was kindly explained to me by @aevyrie on this Bevy issue: https://github.com/bevyengine/bevy/issues/4010